### PR TITLE
Added an Alarm for when Powerwall is off the Grid

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -31,5 +31,8 @@
   },
   "1.3.1": {
     "en": "Fix capability issue"
+  },
+  "1.4.0": {
+    "en": "Add off grid status. Fix Solar so never goes below 0"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.tesla.energy",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#e82127",
@@ -50,7 +50,8 @@
         "measure_battery",
         "grid_power",
         "home_power",
-        "solar_power"
+        "solar_power",
+        "alarm_off_grid"
       ],
       "images": {
         "large": "/drivers/tesla-backup-gateway/assets/images/large.jpg",

--- a/.homeycompose/capabilities/alarm_off_grid.json
+++ b/.homeycompose/capabilities/alarm_off_grid.json
@@ -6,16 +6,8 @@
     "de": "Netzbezug alarm"
   },
   "icon": "/assets/capabilities/alarm-off-grid.svg",
-  "units": {
-    "en": ""
-  },
-  "insights": false,
-  "desc": {
-    "en": "Off Grid Alarm"
-  },
-  "chartType": "stepLine",
-  "decimals": 2,
-  "getable": true,
+    "insights": false,
+    "getable": true,
   "setable": false,
   "uiComponent": "sensor"
 }

--- a/.homeycompose/capabilities/alarm_off_grid.json
+++ b/.homeycompose/capabilities/alarm_off_grid.json
@@ -1,0 +1,21 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Off Grid Alarm",
+    "nl": "Netverbruik alarm",
+    "de": "Netzbezug alarm"
+  },
+  "icon": "/assets/capabilities/alarm-off-grid.svg",
+  "units": {
+    "en": ""
+  },
+  "insights": false,
+  "desc": {
+    "en": "Off Grid Alarm"
+  },
+  "chartType": "stepLine",
+  "decimals": 2,
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.tesla.energy",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#e82127",
@@ -147,6 +147,33 @@
             "filter": "driver_id=tesla-backup-gateway"
           }
         ]
+      },
+      {
+        "id": "alarm_off_grid_changed",
+        "title": {
+          "en": "Powerwall Off Grid Alarm updated"
+        },
+        "tokens": [
+          {
+            "name": "alarm_off_grid",
+            "type": "boolean",
+            "title": {
+              "en": "Off Grid Alarm",
+              "nl": "Netverbruik alarm",
+              "de": "Netzbezug alarm"
+            },
+            "example": {
+              "en": "false"
+            }
+          }
+        ],
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=tesla-backup-gateway"
+          }
+        ]
       }
     ]
   },
@@ -163,7 +190,8 @@
         "measure_battery",
         "grid_power",
         "home_power",
-        "solar_power"
+        "solar_power",
+        "alarm_off_grid"
       ],
       "images": {
         "large": "/drivers/tesla-backup-gateway/assets/images/large.png",
@@ -250,6 +278,27 @@
     }
   ],
   "capabilities": {
+    "alarm_off_grid": {
+      "type": "boolean",
+      "title": {
+        "en": "Off Grid Alarm",
+        "nl": "Netverbruik alarm",
+        "de": "Netzbezug alarm"
+      },
+      "icon": "/assets/capabilities/alarm-off-grid.svg",
+      "units": {
+        "en": ""
+      },
+      "insights": false,
+      "desc": {
+        "en": "Off Grid Alarm"
+      },
+      "chartType": "stepLine",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
     "battery_power": {
       "type": "number",
       "title": {

--- a/assets/capabilities/alarm-off-grid.svg
+++ b/assets/capabilities/alarm-off-grid.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 30 30" fill="#000000" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 26 11 A 1 1 0 1 0 26 13 A 1 1 0 1 0 26 11 z M 15 2 A 1 1 0 1 0 15 4 A 1 1 0 1 0 15 2 z M 4 11 A 1 1 0 1 0 4 13 A 1 1 0 1 0 4 11 z M 25 11 h -3 V 6 c 0 -0.6 0.4 -1 1 -1 h 1 c 0.6 0 1 0.4 1 1 V 11 z" style="" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+  <path d="M 15 3 v 10 h 11 l 0.7 -1.7 L 15.7 2.3 L 15 3 z M 14.3 2.3 L 3.3 11.3 L 4 13 h 11 V 3 L 14.3 2.3 z" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+  <path d="M 5.1 0.9 S 16 18.1 16 18.1" fill="rgb(255, 255, 255)" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+  <text style="font-family: Arial, sans-serif; font-size: 10.1px; font-weight: 700; text-transform: capitalize; white-space: pre;" transform="matrix(1.1212210655212402, 0, 0, 1.1074670553207397, -1.863955020904541, -0.8993989825248718)" x="11.459" y="21.774">X</text>
+  <rect x="4.256" y="13.065" width="2.415" height="11.91" style="stroke: rgb(0, 0, 0);" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+  <rect x="3.478" y="26.939" width="23.165" height="0.368" style="stroke: rgb(0, 0, 0);" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+  <rect x="3.813" y="-82552.445" width="0.858" height="3.355" style="stroke: rgb(0, 0, 0);" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 10.796411514282227, 82575.453125)"/>
+  <rect x="23.205" y="13.106" width="2.415" height="11.91" style="stroke: rgb(0, 0, 0);" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 0, 0)"/>
+</svg>

--- a/drivers/tesla-backup-gateway/api.ts
+++ b/drivers/tesla-backup-gateway/api.ts
@@ -4,6 +4,7 @@ import {
   ApiBatterySoeResponse,
   ApiMeterAggregatesResponse,
   ApiSitenameResponse,
+  ApiGridStatusResponse
 } from "./types";
 
 const ENDPOINTS = {
@@ -12,6 +13,7 @@ const ENDPOINTS = {
   siteName: "/site_info/site_name",
   batterySoc: "/system_status/soe",
   meterAggregates: "/meters/aggregates",
+  gridStatus: "/system_status/grid_status"
 };
 
 class TeslaBackupGatewayApi {
@@ -105,6 +107,15 @@ class TeslaBackupGatewayApi {
       );
 
     return meterAggregatesResponse;
+  }
+
+  async getGridStatus() {
+    const gridStatusResponse =
+      await this.fetchApiEndpoint<ApiGridStatusResponse>(
+        ENDPOINTS.gridStatus
+      );
+
+    return gridStatusResponse;
   }
 }
 

--- a/drivers/tesla-backup-gateway/device.ts
+++ b/drivers/tesla-backup-gateway/device.ts
@@ -26,10 +26,8 @@ class TeslaBackupGatewayDevice extends Device {
       );
     }
 
-    // Temporary: add measure_battery capability if not attached to device
-    if (!this.hasCapability("measure_battery")) {
-      await this.addCapability("measure_battery");
-    }
+    // Add any missing capabilities due to app updates
+    await this.updateCapabilities();
 
     // Initialize update interval
     this.updateInterval = this.homey.setInterval(
@@ -55,6 +53,17 @@ class TeslaBackupGatewayDevice extends Device {
 
   onDeleted() {
     this.homey.clearInterval(this.updateInterval);
+  }
+
+  // Add capabilities if not attached to device
+  async updateCapabilities(){
+    if (!this.hasCapability("measure_battery")) {
+      await this.addCapability("measure_battery");
+    }
+
+    if (!this.hasCapability('alarm_off_grid')){
+        await this.addCapability('alarm_off_grid');
+    }
   }
 
   async updateDeviceState() {

--- a/drivers/tesla-backup-gateway/driver.compose.json
+++ b/drivers/tesla-backup-gateway/driver.compose.json
@@ -10,7 +10,8 @@
     "measure_battery",
     "grid_power",
     "home_power",
-    "solar_power"
+    "solar_power",
+    "alarm_off_grid"
   ],
   "images": {
     "large": "/drivers/tesla-backup-gateway/assets/images/large.png",

--- a/drivers/tesla-backup-gateway/driver.flow.compose.json
+++ b/drivers/tesla-backup-gateway/driver.flow.compose.json
@@ -65,8 +65,8 @@
       ]
     },
     {
-      "id": "alarm_off_grid_changed",
-      "title": { "en": "Powerwall Off Grid Alarm updated" },
+      "id": "alarm_off_grid_true",
+      "title": { "en": "Powerwall is off the grid" },
       "tokens": [
         {
           "name": "alarm_off_grid",
@@ -76,9 +76,26 @@
             "nl": "Netverbruik alarm",
             "de": "Netzbezug alarm"
           },
-          "example": { "en": "false" }
+          "example": { "en": "Yes" }
+        }
+      ]
+    },
+    {
+      "id": "alarm_off_grid_false",
+      "title": { "en": "Powerwall is on the grid" },
+      "tokens": [
+        {
+          "name": "alarm_off_grid",
+          "type": "boolean",
+          "title": {
+            "en": "Off Grid Alarm",
+            "nl": "Netverbruik alarm",
+            "de": "Netzbezug alarm"
+          },
+          "example": { "en": "No" }
         }
       ]
     }
+    
   ]
 }

--- a/drivers/tesla-backup-gateway/driver.flow.compose.json
+++ b/drivers/tesla-backup-gateway/driver.flow.compose.json
@@ -63,6 +63,22 @@
           "example": { "en": "4792" }
         }
       ]
+    },
+    {
+      "id": "alarm_off_grid_changed",
+      "title": { "en": "Powerwall Off Grid Alarm updated" },
+      "tokens": [
+        {
+          "name": "alarm_off_grid",
+          "type": "boolean",
+          "title": {
+            "en": "Off Grid Alarm",
+            "nl": "Netverbruik alarm",
+            "de": "Netzbezug alarm"
+          },
+          "example": { "en": "false" }
+        }
+      ]
     }
   ]
 }

--- a/drivers/tesla-backup-gateway/types.ts
+++ b/drivers/tesla-backup-gateway/types.ts
@@ -124,3 +124,8 @@ export interface ApiMeterAggregatesResponse {
     i_c_current: number;
   };
 }
+
+export interface ApiGridStatusResponse {
+  grid_status: string;
+  grid_services_active: boolean;
+}


### PR DESCRIPTION
Added an Alarm for when off the Grid
![image](https://github.com/DiedB/Homey-TeslaEnergy/assets/4244440/756da200-927b-4e25-8570-6193bcba8692)

![image](https://github.com/DiedB/Homey-TeslaEnergy/assets/4244440/78a0052c-5340-4954-b80c-176675164e5f)

Also added the Capability to use this in flows to trigger when:
- Powerwall is off the grid
- Powerwall is on the grid
![image](https://github.com/DiedB/Homey-TeslaEnergy/assets/4244440/0b5de88b-941d-4e45-a6c2-6d9194354a31)
e.g.
![image](https://github.com/DiedB/Homey-TeslaEnergy/assets/4244440/49d161c4-fd28-45cd-9848-82bad1f39835)

Also populates an "Off Grid Alarm" tag to use in logic conditions e.g.
![image](https://github.com/DiedB/Homey-TeslaEnergy/assets/4244440/69b9adc8-3db9-4841-be89-cdcfa4dfa69a)

Tested using the Tesla app to go off grid. Havent had a real Powercut to test with yet.


Finally so you don't have to add a flow to compensate for the Solar Power value going negative from the Tesla API, it now will set it to 0 for negative solar values.